### PR TITLE
Enable platform-dependent include path.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,10 +18,15 @@ fn main() {
 
   match env::var("JAVA_HOME") {
     Ok(val) => { 
-      minidfs_config
-        .include(format!("{}/include/", val))
-        // TODO - to be changed to consider a dependent platform.
-        .include(format!("{}/include/linux", val));
+      minidfs_config.include(format!("{}/include/", val));
+      if cfg!(target_os = "linux") {
+        minidfs_config
+          .include(format!("{}/include/linux", val));
+      } else if cfg!(target_os = "macos") {
+        minidfs_config
+          .include(format!("{}/include/darwin", val));
+      }
+      // TODO - to be changed to consider a dependent platform.
     },
     Err(e) => { panic!("JAVA_HOME shell environment must be set: {}", e); }
   }


### PR DESCRIPTION
Hi, I added some codes to enable platform-dependent include path.
I'm a newbie of Rust, so my patch may not follow the conventional Rust code style. Welcome any comments.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hyunsik/hdfs-rs/2)

<!-- Reviewable:end -->
